### PR TITLE
slim composer install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/test export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+infection.json.dist export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
exclude everything but source, license, and composer config when installed via composer