### PR TITLE
increase coverage

### DIFF
--- a/test/LogLevelConfigurationTest.php
+++ b/test/LogLevelConfigurationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace AbacaphiliacTest\Doctrine;
+
+use Abacaphiliac\Doctrine\LogLevelConfiguration;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+
+/**
+ * @covers \Abacaphiliac\Doctrine\LogLevelConfiguration
+ */
+class LogLevelConfigurationTest extends TestCase
+{
+    /** @var LogLevelConfiguration */
+    private $sut;
+
+    protected function setUp()
+    {
+        $this->sut = new LogLevelConfiguration([
+            LogLevel::DEBUG => 0,
+            LogLevel::INFO => 10,
+            LogLevel::NOTICE => 20,
+            LogLevel::WARNING => 30,
+            LogLevel::ERROR => 40,
+            LogLevel::CRITICAL => 50,
+            LogLevel::ALERT => 60,
+            LogLevel::EMERGENCY => 70,
+        ]);
+    }
+
+    public static function dataValidLevels(): array
+    {
+        return [
+            [-1, null],
+            [0, null],
+            [1, LogLevel::DEBUG],
+            [9, LogLevel::DEBUG],
+            [10, LogLevel::INFO],
+            [11, LogLevel::INFO],
+            [19, LogLevel::INFO],
+            [20, LogLevel::NOTICE],
+            [21, LogLevel::NOTICE],
+            [29, LogLevel::NOTICE],
+            [30, LogLevel::WARNING],
+            [31, LogLevel::WARNING],
+            [39, LogLevel::WARNING],
+            [40, LogLevel::ERROR],
+            [41, LogLevel::ERROR],
+            [49, LogLevel::ERROR],
+            [50, LogLevel::CRITICAL],
+            [51, LogLevel::CRITICAL],
+            [59, LogLevel::CRITICAL],
+            [60, LogLevel::ALERT],
+            [61, LogLevel::ALERT],
+            [69, LogLevel::ALERT],
+            [70, LogLevel::EMERGENCY],
+            [71, LogLevel::EMERGENCY],
+            [79, LogLevel::EMERGENCY],
+        ];
+    }
+
+    /**
+     * @dataProvider dataValidLevels
+     * @param float $durationMs
+     * @param string | null $expected
+     */
+    public function testValidLevels(
+        float $durationMs,
+        ?string $expected
+    ): void {
+        $actual = $this->sut->getApplicableLogLevel($durationMs / 1000);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testInvalidLogLevel(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('invalid LogLevel detected: "InvalidLevel", please choose from: "' . print_r([
+            'EMERGENCY' => 'emergency',
+            'ALERT' => 'alert',
+            'CRITICAL' => 'critical',
+            'ERROR' => 'error',
+            'WARNING' => 'warning',
+            'NOTICE' => 'notice',
+            'INFO' => 'info',
+            'DEBUG' => 'debug',
+        ], true) . '"');
+
+        new LogLevelConfiguration([
+            'InvalidLevel' => 1000,
+        ]);
+    }
+}

--- a/test/PsrSqlLoggerConfigurableLogLevelsTest.php
+++ b/test/PsrSqlLoggerConfigurableLogLevelsTest.php
@@ -4,6 +4,7 @@ namespace AbacaphiliacTest\Doctrine;
 
 use Abacaphiliac\Doctrine\LogLevelConfiguration;
 use Abacaphiliac\Doctrine\PsrSqlLoggerConfigurableLogLevels;
+use Psr\Log\LoggerInterface;
 use Psr\Log\Test\TestLogger;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -13,7 +14,7 @@ use stdClass;
 use function usleep;
 
 /**
- * @covers \Abacaphiliac\Doctrine\PsrSqlLogger
+ * @covers \Abacaphiliac\Doctrine\PsrSqlLoggerConfigurableLogLevels
  */
 class PsrSqlLoggerConfigurableLogLevelsTest extends TestCase
 {
@@ -115,6 +116,53 @@ class PsrSqlLoggerConfigurableLogLevelsTest extends TestCase
             new LogLevelConfiguration([
                 'SOME_INVALID_LOG_LEVEL' => 100,
             ])
+        );
+    }
+
+    public function testInvalidDefaultLogLevel() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new PsrSqlLoggerConfigurableLogLevels(
+            new class implements LoggerInterface {
+                public function emergency($message, array $context = array())
+                {
+                }
+
+                public function alert($message, array $context = array())
+                {
+                }
+
+                public function critical($message, array $context = array())
+                {
+                }
+
+                public function error($message, array $context = array())
+                {
+                }
+
+                public function warning($message, array $context = array())
+                {
+                }
+
+                public function notice($message, array $context = array())
+                {
+                }
+
+                public function info($message, array $context = array())
+                {
+                }
+
+                public function debug($message, array $context = array())
+                {
+                }
+
+                public function log($level, $message, array $context = array())
+                {
+                }
+            },
+            new LogLevelConfiguration([
+            ]),
+            'InvalidLevel'
         );
     }
 


### PR DESCRIPTION
```bash
vendor/bin/phpunit --coverage-text
```
coverage report in master doesn't include the newest classes:
```text
Code Coverage Report:    
  2020-01-27 03:31:26    
                         
 Summary:                
  Classes: 50.00% (2/4)  
  Methods: 25.00% (5/20) 
  Lines:   29.76% (25/84)

\Abacaphiliac\Doctrine::Abacaphiliac\Doctrine\PsrSqlLogger
  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 23/ 23)
\Abacaphiliac\Doctrine::Abacaphiliac\Doctrine\PsrSqlParamsLogger
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  2/  2)
```

fixing the coverage annotation yields:
```text
Code Coverage Report:    
  2020-01-27 03:31:48    
                         
 Summary:                
  Classes: 75.00% (3/4)  
  Methods: 95.00% (19/20)
  Lines:   95.24% (80/84)

\Abacaphiliac\Doctrine::Abacaphiliac\Doctrine\LogLevelConfiguration
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 24/ 24)
\Abacaphiliac\Doctrine::Abacaphiliac\Doctrine\PsrSqlLogger
  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 23/ 23)
\Abacaphiliac\Doctrine::Abacaphiliac\Doctrine\PsrSqlLoggerConfigurableLogLevels
  Methods:  87.50% ( 7/ 8)   Lines:  88.57% ( 31/ 35)
\Abacaphiliac\Doctrine::Abacaphiliac\Doctrine\PsrSqlParamsLogger
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  2/  2)
```

turns out that TestLogger implements `__call` so even invalid log levels are `callable`. added a test with an anonymous implementation to cover the error.

i prefer a test-case per source class, so i added some data-provider tests to cover the configuration explicitly.